### PR TITLE
bug fix in test2.R

### DIFF
--- a/gl/test2.R
+++ b/gl/test2.R
@@ -6,7 +6,7 @@ if(is.na(cores)) cores <- detectCores()
 registerDoParallel(cores)
 
 system.time(
- rnorm(10^8); return(0)
+ rnorm(10^8)
 ) -> time0
 
 system.time(


### PR DESCRIPTION
The semicolon is giving me an error when running the code using "sbatch test2.sbat".

Test Plan:
Run "sbatch test2.sbat" from greatlake